### PR TITLE
Always send data in body if a RequestData instance is given

### DIFF
--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -134,10 +134,19 @@ class HttpRequest extends \lang\Object {
    * @param   bool withBody
    */
   protected function getPayload($withBody) {
-   if ($this->parameters instanceof RequestData) {
+    static $params= [
+      HttpConstants::HEAD    => true,
+      HttpConstants::GET     => true,
+      HttpConstants::DELETE  => true,
+      HttpConstants::OPTIONS => true
+    ];
+
+    if ($this->parameters instanceof RequestData) {
       $this->addHeaders($this->parameters->getHeaders());
       $query= '&'.$this->parameters->getData();
+      $useParams= false;
     } else {
+      $useParams= isset($params[$this->method]);
       $query= '';
       foreach ($this->parameters as $name => $value) {
         if (is_array($value)) {
@@ -152,25 +161,19 @@ class HttpRequest extends \lang\Object {
     $target= $this->target;
     $body= '';
 
-    // Which HTTP method? GET and HEAD use query string, POST etc. use
-    // body for passing parameters
-    switch ($this->method) {
-      case HttpConstants::HEAD: case HttpConstants::GET: case HttpConstants::DELETE: case HttpConstants::OPTIONS:
-        if (null !== $this->url->getQuery()) {
-          $target.= '?'.$this->url->getQuery().(empty($query) ? '' : $query);
-        } else {
-          $target.= empty($query) ? '' : '?'.substr($query, 1);
-        }
-        break;
-
-      case HttpConstants::POST: case HttpConstants::PUT: case HttpConstants::TRACE: default:
-        if ($withBody) $body= substr($query, 1);
-        if (null !== $this->url->getQuery()) $target.= '?'.$this->url->getQuery();
-        $this->headers['Content-Length']= array(max(0, strlen($query)- 1));
-        if (empty($this->headers['Content-Type'])) {
-          $this->headers['Content-Type']= array('application/x-www-form-urlencoded');
-        }
-        break;
+    if ($useParams) {
+      if (null !== $this->url->getQuery()) {
+        $target.= '?'.$this->url->getQuery().(empty($query) ? '' : $query);
+      } else {
+        $target.= empty($query) ? '' : '?'.substr($query, 1);
+      }
+    } else {
+      if ($withBody) $body= substr($query, 1);
+      if (null !== $this->url->getQuery()) $target.= '?'.$this->url->getQuery();
+      $this->headers['Content-Length']= array(max(0, strlen($query)- 1));
+      if (empty($this->headers['Content-Type'])) {
+        $this->headers['Content-Type']= array('application/x-www-form-urlencoded');
+      }
     }
 
     $request= sprintf(

--- a/src/test/php/peer/http/unittest/HttpRequestTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpRequestTest.class.php
@@ -130,17 +130,6 @@ class HttpRequestTest extends TestCase {
   }
 
   #[@test]
-  public function get_url_with_RequestData_parameters() {
-    $r= new HttpRequest(new \peer\URL('http://example.com/'));
-    $r->setMethod(HttpConstants::GET);
-    $r->setParameters(new RequestData('a=b&c=d'));
-    $this->assertEquals(
-      "GET /?a=b&c=d HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
-      $r->getRequestString()
-    );
-  }
-
-  #[@test]
   public function post_url_with_RequestData_parameters() {
     $r= new HttpRequest(new \peer\URL('http://example.com/'));
     $r->setMethod(HttpConstants::POST);
@@ -436,12 +425,23 @@ class HttpRequestTest extends TestCase {
   }
 
   #[@test]
-  public function with_1byte_body() {
+  public function post_with_1byte_body() {
     $r= new HttpRequest(new \peer\URL('http://example.com/'));
     $r->setMethod(HttpConstants::POST);
     $r->setParameters(new RequestData('1'));
     $this->assertEquals(
       "POST / HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\nContent-Length: 1\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n",
+      $r->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function delete_with_1byte_body() {
+    $r= new HttpRequest(new \peer\URL('http://example.com/'));
+    $r->setMethod(HttpConstants::DELETE);
+    $r->setParameters(new RequestData('1'));
+    $this->assertEquals(
+      "DELETE / HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\nContent-Length: 1\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n",
       $r->getHeaderString()
     );
   }


### PR DESCRIPTION
```php
$request= $conn->create(new HttpRequest());
$request->setParameters(['a' => 'b']);   // Will choose based on defaults[1]
$request->setParameters(new RequestData(...));  // Will *ALWAYS* use body
```

Really, this should be separate.

*[1]: GET, HEAD, OPTIONS, DELETE = use params, other verbs = use body*