### PR TITLE
Implement HTTP Digest Authentication - RFC 2617

### DIFF
--- a/src/main/php/peer/http/Authorization.class.php
+++ b/src/main/php/peer/http/Authorization.class.php
@@ -1,0 +1,32 @@
+<?php namespace peer\http;
+
+use lang\Object;
+use security\SecureString;
+
+abstract class Authorization extends Object {
+  protected $username;
+  protected $password;
+
+  /** @return string */
+  public function username() { return $this->username; }
+
+  /** @param string u */
+  public function setUsername($u) { $this->username= $u; }
+  
+  /** @return security.SecureString */
+  public function password() { return $this->password; }
+
+  /** @param security.SecureString p */
+  public function setPassword(SecureString $p) { $this->password= $p; }
+
+  /**
+   * Sign HTTP request
+   * 
+   * @param  peer.http.HttpRequest $request
+   */
+  abstract function sign(HttpRequest $request);
+
+  public static function fromChallenge($header, $user, $pass) {
+    throw new MethodNotImplementedException(__METHOD__, 'Should be abstract');
+  }
+}

--- a/src/main/php/peer/http/Authorizations.class.php
+++ b/src/main/php/peer/http/Authorizations.class.php
@@ -1,0 +1,65 @@
+<?php namespace peer\http;
+
+use lang\Object;
+use lang\XPClass;
+use lang\reflect\TargetInvocationException;
+use security\SecureString;
+use lang\IllegalStateException;
+
+/**
+ * Authorization factory class for HTTP
+ *
+ */
+class Authorizations extends Object {
+  const AUTH_HEADER= 'WWW-Authenticate';
+  protected $impl= [
+    ['startsWith' => 'Basic ', 'impl' => 'peer.http.BasicAuthorization'],
+    ['startsWith' => 'Digest ', 'impl' => 'peer.http.DigestAuthorization']
+  ];
+
+  public function required(HttpResponse $response) {
+    return HttpConstants::STATUS_AUTHORIZATION_REQUIRED == $response->getStatusCode();
+  }
+
+  public function create(HttpResponse $response, $user, SecureString $pass) {
+    if (!$this->required($response)) {
+      throw new IllegalStateException('Request had not been rejected, will not create authorization.');
+    }
+
+    if (1 != sizeof($response->header(self::AUTH_HEADER))) {
+      throw new IllegalStateException('No authentication type indicated.');
+    }
+
+    $header= $response->header(self::AUTH_HEADER)[0];
+    foreach ($this->impl as $impl) {
+      if (0 == strncmp($impl['startsWith'], $header, strlen($impl['startsWith']))) {
+        try {
+          return XPClass::forName($impl['impl'])->getMethod('fromChallenge')->invoke(
+            null,
+            [$header, $user, $pass]
+          );
+        } catch (TargetInvocationException $e) {
+          throw $e->getCause();
+        }
+      }
+    }
+
+    throw new IllegalStateException('Unknown authorization type.');
+  }
+
+  /**
+   * Create authorization from challenge data from given
+   * HTTP request.
+   *
+   * @param  peer.http.HttpResponse $response
+   * @param  string $user
+   * @param  security.SecureString $pass
+   * @return peer.http.Authorization
+   * @throws lang.IllegalStateException If request hadn't challenged
+   * @throws lang.IllegalStateException If HTTP status not equal 401
+   * @throws lang.IllegalStateException If Unknown authorization type was used
+   */
+  public static function fromResponse(HttpResponse $response, $user, SecureString $pass) {
+    return (new self())->create($response, $user, $pass);
+  }
+}

--- a/src/main/php/peer/http/BasicAuthorization.class.php
+++ b/src/main/php/peer/http/BasicAuthorization.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http;
 
+use lang\Object;
 use peer\Header;
 use security\SecureString;
 
@@ -14,13 +15,9 @@ use security\SecureString;
  * password are passed over the network as cleartext.
  * </quote>
  *
- * @see  http://www.owasp.org/downloads/http_authentication.txt
  * @see  rfc://2617 
  */
-class BasicAuthorization extends Header {
-  public
-    $user = '',
-    $pass = '';
+class BasicAuthorization extends Authorization {
   
   /**
    * Constructor
@@ -29,45 +26,41 @@ class BasicAuthorization extends Header {
    * @param   var $pass security.SecureString or plain string
    */
   public function __construct($user, $pass) {
-    $this->user= $user;
+    $this->setUsername($user);
 
     if (!$pass instanceof SecureString) {
-      $pass= new SecureString($pass);
+      $this->setPassword(new SecureString($pass));
+    } else {
+      $this->setPassword($pass);
     }
-
-    $this->pass= $pass;
-    parent::__construct('Authorization', 'Basic');
   }
 
-  /**
-   * Returns the username
-   *
-   * @return  string
-   */    
-  public function getUser() {
-    return $this->user;
-  }
-  
-  /**
-   * Returns the password
-   *
-   * @return  string
-   */    
-  public function getPassword() {
-    return $this->pass;
-  }
+  /** @return string */
+  public function getUser() { return $this->user; }
   
   /**
    * Returns a BasicAuthorization object from header value; returns
    * FALSE on error.
    *
-   * @param   stirng $value The header value
+   * @param   string $value The header value
    * @return  peer.http.BasicAuthorization
    */    
   public static function fromValue($value) {
     if (!preg_match('/^Basic (.*)$/', $value, $matches)) return false;
     list($user, $password)= explode(':', base64_decode($matches[1]), 2);
     return new self($user, new SecureString($password));
+  }
+
+  /**
+   * Create BasicAuthorization object from challenge
+   *
+   * @param  string $header
+   * @param  string $user
+   * @param  security.SecureString $pass
+   * @return self
+   */
+  public static function fromChallenge($header, $user, $pass) {
+    return new self($user, $pass);
   }
   
   /**
@@ -76,6 +69,18 @@ class BasicAuthorization extends Header {
    * @return  string value
    */
   public function getValueRepresentation() {
-    return $this->value.' '.base64_encode($this->user.':'.$this->pass->getCharacters());
+    return 'Basic '.base64_encode($this->username.':'.$this->password->getCharacters());
+  }
+
+  /**
+   * Sign HTTP request
+   *
+   * @param  peer.http.HttpRequest $request
+   */
+  public function sign(HttpRequest $request) {
+    $request->setHeader(
+      'Authorization',
+      new Header('Authorization', $this->getValueRepresentation())
+    );
   }
 }

--- a/src/main/php/peer/http/DigestAuthorization.class.php
+++ b/src/main/php/peer/http/DigestAuthorization.class.php
@@ -1,0 +1,240 @@
+<?php namespace peer\http;
+
+use lang\Object;
+use peer\Header;
+use security\SecureString;
+use lang\IllegalStateException;
+use lang\MethodNotImplementedException;
+
+/**
+ * Digest Authorization header
+ *
+ * <quote>
+ * "HTTP/1.0", includes the specification for a Basic Access
+ * Authentication scheme. This scheme is not considered to be a secure
+ * method of user authentication (unless used in conjunction with some
+ * external secure system such as SSL), as the user name and
+ * password are passed over the network as cleartext.
+ * </quote>
+ *
+ * @see  rfc://2617
+ * @see  https://en.wikipedia.org/wiki/Digest_access_authentication
+ */
+class DigestAuthorization extends Authorization {
+
+  /* Server values */
+  private $realm;       // Realm
+  private $qop;         // Quality of protection
+  private $nonce;       // Server nonce
+  private $opaque;      // Opaque - optional
+
+  /* Internal state */
+  private $counter= 1;  // Client request counter
+  private $cnonce;      // Client nonce
+
+  /**
+   * Constructor
+   *
+   * @param string $realm
+   * @param string $qop
+   * @param string $nonce
+   * @param string $opaque
+   */
+  public function __construct($realm, $qop, $nonce, $opaque) {
+    $this->realm= $realm;
+    $this->qop= $qop;
+    $this->nonce= $nonce;
+    $this->opaque= $opaque;
+
+    // Initialize client nonce
+    $this->cnonce();
+  }
+
+  /**
+   * Read digest realm and accompanying data from HTTP response
+   * and construct an instance of this class.
+   *
+   * @param  string $header
+   * @param  string $user
+   * @param  security.SecureString $pass
+   * @return peer.http.DigestAuthorization
+   */
+  public static function fromChallenge($header, $user, $pass) {
+    if (!preg_match_all('#(([a-z]+)=("[^"$]+)")#m', $header, $matches, PREG_SET_ORDER)) {
+      throw new IllegalStateException('Invalid WWW-Authenticate line');
+    }
+
+    $values= [
+      'algorithm' => 'md5',
+      'opaque'    => null
+    ];
+    foreach ($matches as $m) {
+      $values[$m[2]]= trim($m[3], '"');
+    }
+
+    if ($values['algorithm'] != 'md5') {
+      throw new MethodNotImplementedException('Digest auth only supported via algo "md5".', 'digest-md5');
+    }
+
+    $auth= new self(
+      $values['realm'],
+      $values['qop'],
+      $values['nonce'],
+      $values['opaque']
+    );
+    $auth->setUsername($user);
+    $auth->setPassword($pass);
+
+    return $auth;
+  }
+
+  /**
+   * Calculate the response code for the given request
+   *
+   * @param  peer.http.HttpRequest $request
+   * @return string
+   */
+  public function hashFor($method, $requestUri) {
+    return md5(implode(':', [
+      $this->ha1(),
+      $this->nonce,
+      sprintf('%08x', $this->counter),
+      $this->cnonce,
+      $this->qop(),
+      $this->ha2($method, $requestUri)
+    ]));
+  }
+
+  public function getValueRepresentation($method, $requestUri) {
+    $parts= [
+      'username'  => $this->username,
+      'realm'     => $this->realm,
+      'nonce'     => $this->nonce,
+      'uri'       => $requestUri,
+      'qop'       => $this->qop(),
+      'nc'        => sprintf('%08x', $this->counter),
+      'cnonce'    => $this->cnonce,
+      'response'  => $this->hashFor($method, $requestUri)
+    ];
+
+    if (sizeof($this->opaque)) {
+      $parts['opaque']= $this->opaque;
+    }
+
+    $digest= '';
+    foreach ($parts as $n => $v) {
+      $digest.= (!ctype_digit($v)
+        ? $n.'="'.$v.'", '
+        : $n.'='.$v.', '
+      );
+    }
+
+    return 'Digest '.rtrim($digest, ', ');
+  }
+
+  /**
+   * Sign the given request; ie. add an Authorization: Digest header
+   * and increase the internal nonce counter.
+   *
+   * @param  peer.http.HttpRequest $request
+   */
+  public function sign(HttpRequest $request) {
+    $url= $request->target;
+
+    $params= [];
+    if (is_array($request->parameters)) $params= array_merge($params, $request->parameters);
+    if ($request->getUrl()->hasParams()) $params= array_merge($params, $request->getUrl()->getParams());
+
+    if (sizeof($params)) {
+      $url.= '?';
+      foreach ($params as $k => $v) {
+        $url.= $k.'='.$v.'&';
+      }
+      $url= substr($url, 0, -1);
+    }
+
+    $request->setHeader('Authorization', new Header(
+      'Authorization',
+      $this->getValueRepresentation($request->method, $url)
+    ));
+
+    // Increase internal counter
+    $this->counter++;
+  }
+
+  /**
+   * Create ha1 value
+   *
+   * @return string
+   */
+  private function ha1() {
+    return md5(implode(':', [$this->username, $this->realm, $this->password->getCharacters()]));
+  }
+
+  /**
+   * Create ha2 value
+   *
+   * @param  string $method
+   * @param  string $requestUri
+   * @return string
+   */
+  private function ha2($method, $requestUri) {
+    return md5(implode(':', [strtoupper($method), $requestUri]));
+  }
+
+  /**
+   * Retrieve quality-of-protection value; hardcoded
+   * @return [type] [description]
+   */
+  private function qop() {
+    $qop= explode(',', $this->qop);
+    if (!in_array('auth', $qop)) {
+      throw new MethodNotImplementedException('QoP not given or not supported (supported: "auth", have: '.\xp::stringOf($this->qop).').');
+    }
+
+    return 'auth';
+  }
+
+  /**
+   * Initialize the client nonce (randomly, if not given a value).
+   *
+   * @param  string $c default null
+   */
+  public function cnonce($c= null) {
+    if (null === $c) {
+      $c= substr(md5(uniqid(time())), 0, 8);
+    }
+
+    $this->cnonce= $c;
+  }
+
+  /**
+   * Check if instance is equal to this instance
+   *
+   * @param  lang.Generic $o
+   * @return boolean
+   */
+  public function equals($o) {
+    if (!$o instanceof self) return false;
+
+    return (
+      $o->realm === $this->realm &&
+      $o->qop === $this->qop &&
+      $o->nonce === $this->nonce &&
+      $o->opaque === $this->opaque
+    );
+  }
+
+  /**
+   * Retrieve string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    $s= $this->getClassName().' ('.$this->hashCode().") {\n";
+    foreach (['realm', 'qop', 'nonce', 'opaque', 'username'] as $attr) {
+      $s.= sprintf("  [ %8s ] %s\n", $attr, \xp::stringOf($this->{$attr}));
+    }
+    return $s.="}\n";
+  }
+}

--- a/src/test/php/peer/http/unittest/AuthorizationsTest.class.php
+++ b/src/test/php/peer/http/unittest/AuthorizationsTest.class.php
@@ -1,0 +1,68 @@
+<?php namespace peer\http\unittest;
+
+use unittest\TestCase;
+use peer\http\HttpResponse;
+use peer\http\Authorizations;
+use io\streams\MemoryInputStream;
+use security\SecureString;
+use peer\http\BasicAuthorization;
+
+class AuthorizationsTest extends TestCase {
+  const USER= 'foo';
+  const PASS= 'bar';
+
+  public function setUp() {
+    $this->cut= new Authorizations();
+  }
+
+  #[@test]
+  public function create_basic_auth() {
+    $res= new HttpResponse(new MemoryInputStream(
+      "HTTP/1.1 401 Authentication required.\r\n".
+      "WWW-Authenticate: Basic realm=\"Auth me!\"\r\n\r\n"
+    ));
+
+    $this->assertInstanceof(
+      'peer.http.BasicAuthorization',
+      $this->cut->create($res, self::USER, new SecureString(self::PASS))
+    );
+  }
+
+  #[@test]
+  public function create_digest_auth() {
+    $res= new HttpResponse(new MemoryInputStream(
+      "HTTP/1.1 401 Authentication required.\r\n".
+      "WWW-Authenticate: Digest realm=\"Auth me!\", qop=\"auth\", nonce=\"12345\"\r\n\r\n"
+    ));
+
+    $this->assertInstanceof(
+      'peer.http.DigestAuthorization',
+      $this->cut->create($res, self::USER, new SecureString(self::PASS))
+    );
+  }
+
+  #[@test, @expect('lang.IllegalStateException')]
+  public function unknown_type_throws_exception() {
+    $res= new HttpResponse(new MemoryInputStream(
+      "HTTP/1.1 401 Authentication required.\r\n".
+      "WWW-Authenticate: Bloafed realm=\"Auth me!\", qop=\"auth\", nonce=\"12345\"\r\n\r\n"
+    ));
+
+    $this->assertInstanceof(
+      'peer.http.DigestAuthorization',
+      $this->cut->create($res, self::USER, new SecureString(self::PASS))
+    );
+  }
+
+  #[@test]
+  public function requires_a_401() {
+    $res= new HttpResponse(new MemoryInputStream('HTTP/1.1 401 Authentication required.'."\r\n\r\n"));
+    $this->assertTrue($this->cut->required($res));
+  }
+
+  #[@test]
+  public function not_required_without_401() {
+    $res= new HttpResponse(new MemoryInputStream('HTTP/1.1 200 Ok'."\r\n\r\n"));
+    $this->assertFalse($this->cut->required($res));
+  }
+}

--- a/src/test/php/peer/http/unittest/DigestAuthTest.class.php
+++ b/src/test/php/peer/http/unittest/DigestAuthTest.class.php
@@ -1,0 +1,234 @@
+<?php namespace peer\http\unittest;
+
+use peer\URL;
+use peer\http\HttpRequest;
+use peer\http\HttpResponse;
+use peer\http\HttpConstants;
+use peer\http\Authorizations;
+use peer\http\DigestAuthorization;
+use security\SecureString;
+use io\streams\MemoryInputStream;
+use lang\MethodNotImplementedException;
+
+class DigestAuthTest extends \unittest\TestCase {
+  const USER = 'Mufasa';
+  const PASS = 'Circle Of Life';
+  const CNONCE = '0a4f113b';
+
+  private $http= null;
+  private $digest= null;
+
+  public function setUp() {
+    $this->http= new MockHttpConnection(new URL('http://example.com:80/dir/index.html'));
+    $this->http->setResponse(new HttpResponse(new MemoryInputStream(
+      "HTTP/1.0 401 Unauthorized\r\n".
+      'WWW-Authenticate: Digest realm="testrealm@host.com", '.
+      'qop="auth,auth-int", '.
+      'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '.
+      'opaque="5ccc069c403ebaf9f0171e9517f40e41"'."\r\n"
+    )));
+
+    $this->digest= new DigestAuthorization(
+      'testrealm@host.com',
+      'auth,auth-int',
+      'dcd98b7102dd2f0e8b11d0f600bfb0c093',
+      '5ccc069c403ebaf9f0171e9517f40e41'
+    );
+    $this->digest->cnonce(self::CNONCE); // Hardcode client nconce, so hashes will be static for the tests
+    $this->digest->setUsername(self::USER);
+    $this->digest->setPassword(new SecureString(self::PASS));
+  }
+
+  private function assertStringContains($needle, $haystack) {
+    if (false === strpos($haystack, $needle)) {
+      $this->fail('String not contained.', $haystack, $needle);
+    }
+  }
+
+  #[@test]
+  public function server_indicates_digest_auth() {
+    $this->assertEquals(HttpConstants::STATUS_AUTHORIZATION_REQUIRED, $this->http->get('/')->getStatusCode());
+  }
+
+  #[@test, @expect('lang.IllegalStateException')]
+  public function no_auth_when_not_indicated() {
+    Authorizations::fromResponse(new HttpResponse(new MemoryInputStream("HTTP/1.0 200 OK")), 'user', new SecureString('pass'));
+  }
+
+  #[@test]
+  public function create_digest_authorization() {
+    $this->assertEquals(
+      $this->digest,
+      Authorizations::fromResponse($this->http->get('/'), 'user', new SecureString('pass'))
+    );
+  }
+
+  #[@test, @expect('lang.MethodNotImplementedException')]
+  public function only_md5_algorithm_supported() {
+    $this->http->setResponse(new HttpResponse(new MemoryInputStream(
+      "HTTP/1.0 401 Unauthorized\r\n".
+      'WWW-Authenticate: Digest realm="testrealm@host.com", '.
+      'qop="auth,auth-int", '.
+      'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '.
+      'opaque="5ccc069c403ebaf9f0171e9517f40e41", '.
+      'algorithm="sha1"'."\r\n"
+    )));
+
+    Authorizations::fromResponse($this->http->get('/'), 'user', new SecureString('pass'));
+  }
+
+  #[@test]
+  public function calculate_digest() {
+    $this->assertEquals(
+      '6629fae49393a05397450978507c4ef1',
+      $this->digest->hashFor('GET', '/dir/index.html')
+    );
+  }
+
+  #[@test]
+  public function sign_adds_authorization_header() {
+    $req= new HttpRequest(new URL('http://example.com:80/dir/index.html'));
+    $this->digest->sign($req);
+
+    $this->assertEquals(
+      "GET /dir/index.html HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: example.com:80\r\n".
+      'Authorization: Digest username="Mufasa", realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/dir/index.html", qop="auth", nc=00000001, cnonce="0a4f113b", response="6629fae49393a05397450978507c4ef1", opaque="5ccc069c403ebaf9f0171e9517f40e41"'.
+      "\r\n\r\n",
+      $req->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function challenge_digest() {
+    $req= new HttpRequest(new URL('http://example.com:80/dir/index.html'));
+    $res= $this->http->send($req);
+
+    if (HttpConstants::STATUS_AUTHORIZATION_REQUIRED === $res->getStatusCode()) {
+      $digest= Authorizations::fromResponse($res, self::USER, new SecureString(self::PASS));
+      $digest->cnonce(self::CNONCE); // Hardcode client nconce, so hashes will be static for the tests
+      $req= $this->http->create($req);
+      $digest->sign($req);
+    }
+
+    $this->assertEquals(
+      "GET /dir/index.html HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: example.com:80\r\n".
+      'Authorization: Digest username="Mufasa", realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/dir/index.html", qop="auth", nc=00000001, cnonce="0a4f113b", response="6629fae49393a05397450978507c4ef1", opaque="5ccc069c403ebaf9f0171e9517f40e41"'.
+      "\r\n\r\n",
+      $req->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function digest_hashes_path() {
+    $this->assertNotEquals(
+      $this->digest->hashFor('GET', '/dir/index.html'),
+      $this->digest->hashFor('GET', '/other/index.html')
+    );
+  }
+
+  #[@test]
+  public function digest_hashes_querystring() {
+    $this->assertNotEquals(
+      $this->digest->hashFor('GET', '/dir/index.html?one'),
+      $this->digest->hashFor('GET', '/dir/index.html?two')
+    );
+  }
+
+  #[@test]
+  public function opaque_is_optional() {
+    $digest= DigestAuthorization::fromChallenge(
+      'WWW-Authenticate: Digest realm="testrealm@host.com", '.
+      'qop="auth,auth-int", '.
+      'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"',
+      self::USER,
+      new SecureString(self::PASS)
+    );
+    $digest->cnonce(self::CNONCE); // Hardcode client nconce, so hashes will be static for the tests
+
+    $this->assertEquals(
+      sprintf('Digest username="Mufasa", realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/", qop="auth", nc=00000001, cnonce="%s", response="%s"',
+        self::CNONCE, $digest->hashFor('GET', '/')
+      ),
+      $digest->getValueRepresentation('GET', '/')
+    );
+  }
+
+  #[@test]
+  public function md5_is_supported_algorithm() {
+    $digest= DigestAuthorization::fromChallenge(
+      'WWW-Authenticate: Digest realm="testrealm@host.com", '.
+      'qop="auth,auth-int", '.
+      'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '.
+      'algorithm="md5"',
+      self::USER,
+      new SecureString(self::PASS)
+    );
+  }
+
+
+  #[@test, @expect('lang.MethodNotImplementedException')]
+  public function only_md5_is_supported_algorithm() {
+    $digest= DigestAuthorization::fromChallenge(
+      'WWW-Authenticate: Digest realm="testrealm@host.com", '.
+      'qop="auth,auth-int", '.
+      'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '.
+      'algorithm="sha1"',
+      self::USER,
+      new SecureString(self::PASS)
+    );
+  }
+
+  #[@test]
+  public function sign_includes_request_params() {
+    $request= new HttpRequest(new URL('http://example.com/foo'));
+    $request->setParameter('param', 'value');
+
+    $this->digest->sign($request);
+    $this->assertStringContains(
+      'uri="/foo?param=value", ',
+      $request->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function sign_includes_url_params() {
+    $request= new HttpRequest(new URL('http://example.com/foo'));
+    $request->getUrl()->setParam('param', 'value');
+
+    $this->digest->sign($request);
+    $this->assertStringContains(
+      'uri="/foo?param=value", ',
+      $request->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function sign_merges_url_params() {
+    $request= new HttpRequest(new URL('http://example.com/foo'));
+    $request->setParameter('param', 'value');
+    $request->getUrl()->setParam('foo', 'bar');
+
+    $this->digest->sign($request);
+    $this->assertStringContains(
+      'uri="/foo?param=value&foo=bar", ',
+      $request->getHeaderString()
+    );
+  }
+
+  #[@test]
+  public function sign_merges_url_params_but_parameters_are_unique() {
+    $request= new HttpRequest(new URL('http://example.com/foo'));
+    $request->setParameter('param', 'value');
+    $request->getUrl()->setParam('param', 'bar');
+
+    $this->digest->sign($request);
+    $this->assertStringContains(
+      'uri="/foo?param=bar", ',
+      $request->getHeaderString()
+    );
+  }
+}

--- a/src/test/php/peer/http/unittest/MockHttpConnection.class.php
+++ b/src/test/php/peer/http/unittest/MockHttpConnection.class.php
@@ -10,10 +10,25 @@ use peer\http\HttpResponse;
  */
 class MockHttpConnection extends \peer\http\HttpConnection {
   protected $lastRequest= null;
+  protected $response= null;
   protected $cat= null;
 
   /** @return string */
   public function lastRequest() { return $this->lastRequest->getRequestString(); }
+
+  public function setResponse(HttpResponse $response) {
+    $this->response= $response;
+  }
+
+  protected function response() {
+    if ($this->response) {
+      $r= $this->response;
+      $this->response= null;
+      return $r;
+    }
+
+    return new HttpResponse(new \io\streams\MemoryInputStream("HTTP/1.0 200 Testing OK\r\n"));
+  }
 
   /**
    * Send a HTTP request
@@ -25,7 +40,7 @@ class MockHttpConnection extends \peer\http\HttpConnection {
     $this->lastRequest= $request;
 
     $this->cat && $this->cat->info('>>>', $request->getHeaderString());
-    $response= new HttpResponse(new \io\streams\MemoryInputStream("HTTP/1.0 200 Testing OK\r\n"));
+    $response= $this->response();
     $this->cat && $this->cat->info('<<<', $response->getHeaderString());
     return $response;
   }


### PR DESCRIPTION
This adds capability to respond to HTTP Digest Authentication challenge;
at the same time, does the following:

* introduce common base class for BasicAuthorization &
  DigestAuthorization, named Authorization

* remove BasicAuthorization's inheritance from peer.Header (this is a BC
  break, but helpers have been added that keep old behaviour in the way
  the class had been intented to be used.

* members have been made non-public (another BC break, but you shouldn't
  access foreign classes members + its not probable that these members
  would be accessed somewhere outside of this package)

With the capabilities in place, you still need to handle HttpConnection
properly to make it talk HTTP digest, ie. it will not automatically
re-try HTTP requests with credentials if responded to with a HTTP 401
status code.