### PR TITLE
Make DELETE put parameters into HTTP body

### DIFF
--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -163,7 +163,7 @@ class HttpRequest extends \lang\Object {
     // Which HTTP method? GET and HEAD use query string, POST etc. use
     // body for passing parameters
     switch ($this->method) {
-      case HttpConstants::HEAD: case HttpConstants::GET: case HttpConstants::DELETE: case HttpConstants::OPTIONS:
+      case HttpConstants::HEAD: case HttpConstants::GET: case HttpConstants::OPTIONS:
         if (null !== $this->url->getQuery()) {
           $target.= '?'.$this->url->getQuery().(empty($query) ? '' : $query);
         } else {
@@ -171,7 +171,7 @@ class HttpRequest extends \lang\Object {
         }
         break;
 
-      case HttpConstants::POST: case HttpConstants::PUT: case HttpConstants::TRACE: default:
+      case HttpConstants::POST: case HttpConstants::PUT: case HttpConstants::DELETE: case HttpConstants::TRACE: default:
         if ($withBody) $body= substr($query, 1);
         if (null !== $this->url->getQuery()) $target.= '?'.$this->url->getQuery();
         $this->headers['Content-Length']= array(max(0, strlen($query)- 1));

--- a/src/test/php/peer/http/unittest/HttpRequestTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpRequestTest.class.php
@@ -135,7 +135,7 @@ class HttpRequestTest extends \unittest\TestCase {
     $r->setMethod(HttpConstants::GET);
     $r->setParameters(new RequestData('a=b&c=d'));
     $this->assertEquals(
-      "GET /?a=b&c=d HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n",
+      "GET / HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\nContent-Length: 7\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\na=b&c=d",
       $r->getRequestString()
     );
   }


### PR DESCRIPTION
This may be used in REST services where DELETE operations need
additional data to operate.

Actually, I'm not sure whether the problem actually is that the decision of whether to put parameters into the Query String or into the HTTP parameter cannot fully be made just by the HTTP verb. A mixed mode is AFAIK not prohibited, but just not possible with this library.