### PR TITLE
Use short array syntax / ::class syntax in annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
@@ -9,12 +11,8 @@ php:
   - hhvm
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/src/main/php/peer/http/FormRequestData.class.php
+++ b/src/main/php/peer/http/FormRequestData.class.php
@@ -24,7 +24,7 @@ class FormRequestData extends RequestData {
   const CRLF    = "\r\n";
 
   protected
-    $parts      = array(),
+    $parts      = [],
     $boundary   = null;
 
   /**
@@ -32,7 +32,7 @@ class FormRequestData extends RequestData {
    *
    * @param   peer.http.FormData[] $parts default array()
    */
-  public function __construct($parts= array()) {
+  public function __construct($parts= []) {
     $this->boundary= '__--boundary-'.uniqid(time()).'--__';
     foreach ($parts as $part) {
       $this->addPart($part);

--- a/src/main/php/peer/http/HttpConnection.class.php
+++ b/src/main/php/peer/http/HttpConnection.class.php
@@ -156,7 +156,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @return  peer.http.HttpResponse response object
    * @throws  io.IOException
    */
-  public function request($method, $parameters, $headers= array()) {
+  public function request($method, $parameters, $headers= []) {
     $r= new HttpRequest($this->url);
     $r->setMethod($method);
     $r->setParameters($parameters);
@@ -171,7 +171,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function get($arg= null, $headers= array()) {
+  public function get($arg= null, $headers= []) {
     return $this->request(HttpConstants::GET, $arg, $headers);
   }
   
@@ -182,7 +182,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function head($arg= null, $headers= array()) {
+  public function head($arg= null, $headers= []) {
     return $this->request(HttpConstants::HEAD, $arg, $headers);
   }
   
@@ -193,7 +193,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function post($arg= null, $headers= array()) {
+  public function post($arg= null, $headers= []) {
     return $this->request(HttpConstants::POST, $arg, $headers);
   }
   
@@ -204,7 +204,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function put($arg= null, $headers= array()) {
+  public function put($arg= null, $headers= []) {
     return $this->request(HttpConstants::PUT, $arg, $headers);
   }
 
@@ -215,7 +215,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function patch($arg= null, $headers= array()) {
+  public function patch($arg= null, $headers= []) {
     return $this->request(HttpConstants::PATCH, $arg, $headers);
   }
 
@@ -226,7 +226,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function delete($arg= null, $headers= array()) {
+  public function delete($arg= null, $headers= []) {
     return $this->request(HttpConstants::DELETE, $arg, $headers);
   }
 
@@ -237,7 +237,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function options($arg= null, $headers= array()) {
+  public function options($arg= null, $headers= []) {
     return $this->request(HttpConstants::OPTIONS, $arg, $headers);
   }
 
@@ -248,7 +248,7 @@ class HttpConnection extends \lang\Object implements Traceable {
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
-  public function trace($arg= null, $headers= array()) {
+  public function trace($arg= null, $headers= []) {
     return $this->request(HttpConstants::TRACE, $arg, $headers);
   }
 

--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -19,8 +19,8 @@ class HttpRequest extends \lang\Object {
     $method     = HttpConstants::GET,
     $target     = '',
     $version    = HttpConstants::VERSION_1_1,
-    $headers    = array('Connection' => array('close')),
-    $parameters = array();
+    $headers    = ['Connection' => ['close']],
+    $parameters = [];
     
   /**
    * Constructor
@@ -42,7 +42,7 @@ class HttpRequest extends \lang\Object {
       $this->setHeader('Authorization', new BasicAuthorization($url->getUser(), new SecureString($url->getPassword())));
     }
     $port= $this->url->getPort(-1);
-    $this->headers['Host']= array($this->url->getHost().(-1 == $port ? '' : ':'.$port));
+    $this->headers['Host']= [$this->url->getHost().(-1 == $port ? '' : ':'.$port)];
     $this->target= $this->url->getPath('/');
   }
 
@@ -89,7 +89,7 @@ class HttpRequest extends \lang\Object {
     } else if (is_array($p)) {
       $params= $p;
     } else {
-      $params= array();
+      $params= [];
     }
     
     $this->parameters= array_diff($params, $this->url->getParams());
@@ -120,7 +120,7 @@ class HttpRequest extends \lang\Object {
       if ($v instanceof Authorization) {
         $v->sign($this);
       } else {
-        $this->headers[$k]= array($v);
+        $this->headers[$k]= [$v];
       }
     }
   }
@@ -178,9 +178,9 @@ class HttpRequest extends \lang\Object {
     } else {
       if ($withBody) $body= substr($query, 1);
       if (null !== $this->url->getQuery()) $target.= '?'.$this->url->getQuery();
-      $this->headers['Content-Length']= array(max(0, strlen($query)- 1));
+      $this->headers['Content-Length']= [max(0, strlen($query)- 1)];
       if (empty($this->headers['Content-Type'])) {
-        $this->headers['Content-Type']= array('application/x-www-form-urlencoded');
+        $this->headers['Content-Type']= ['application/x-www-form-urlencoded'];
       }
     }
 

--- a/src/main/php/peer/http/HttpResponse.class.php
+++ b/src/main/php/peer/http/HttpResponse.class.php
@@ -14,13 +14,13 @@ class HttpResponse extends \lang\Object {
     $statuscode    = 0,
     $message       = '',
     $version       = '',
-    $headers       = array(),
+    $headers       = [],
     $chunked       = null;
   
   protected
     $stream        = null,
     $buffer        = '',
-    $_headerlookup = array();
+    $_headerlookup = [];
     
   /**
    * Constructor
@@ -112,7 +112,7 @@ class HttpResponse extends \lang\Object {
         $k= $this->_headerlookup[$l];
       }
       if (!isset($this->headers[$k])) {
-        $this->headers[$k]= array($v);
+        $this->headers[$k]= [$v];
       } else {
         $this->headers[$k][]= $v;
       }
@@ -274,7 +274,7 @@ class HttpResponse extends \lang\Object {
    * @return  [:string] headers
    */
   public function getHeaders() {
-    $headers= array();
+    $headers= [];
     foreach ($this->headers as $name => $values) {
       $headers[$name]= end($values);
     }

--- a/src/main/php/peer/http/HttpUtil.class.php
+++ b/src/main/php/peer/http/HttpUtil.class.php
@@ -35,7 +35,7 @@ class HttpUtil extends \lang\Object {
    * @return  string
    * @throws  peer.http.UnexpectedResponseException
    */
-  public static function get($connection, $params= array(), $headers= array()) {
+  public static function get($connection, $params= [], $headers= []) {
     $redirected= 0;
     do {
       try {

--- a/src/main/php/peer/http/P3PHeader.class.php
+++ b/src/main/php/peer/http/P3PHeader.class.php
@@ -71,7 +71,7 @@ define('P3PC_CATEGORIES_OTHER_CATEGORY',    'OTC');
 class P3PHeader extends Header {
   public 
     $policyref = '',
-    $compact   = array();
+    $compact   = [];
 
   /**
    * Constructor

--- a/src/main/php/peer/http/RequestData.class.php
+++ b/src/main/php/peer/http/RequestData.class.php
@@ -24,7 +24,7 @@ class RequestData extends \lang\Object {
    * @return  peer.Header[]
    */
   public function getHeaders() {
-    return array();
+    return [];
   }
   
   /**

--- a/src/test/php/peer/http/unittest/AuthorizationsTest.class.php
+++ b/src/test/php/peer/http/unittest/AuthorizationsTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http\unittest;
 
+use lang\IllegalStateException;
 use unittest\TestCase;
 use peer\http\HttpResponse;
 use peer\http\Authorizations;
@@ -41,7 +42,7 @@ class AuthorizationsTest extends TestCase {
     );
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function unknown_type_throws_exception() {
     $res= new HttpResponse(new MemoryInputStream(
       "HTTP/1.1 401 Authentication required.\r\n".

--- a/src/test/php/peer/http/unittest/DigestAuthTest.class.php
+++ b/src/test/php/peer/http/unittest/DigestAuthTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http\unittest;
 
+use lang\IllegalStateException;
 use peer\URL;
 use peer\http\HttpRequest;
 use peer\http\HttpResponse;
@@ -50,7 +51,7 @@ class DigestAuthTest extends \unittest\TestCase {
     $this->assertEquals(HttpConstants::STATUS_AUTHORIZATION_REQUIRED, $this->http->get('/')->getStatusCode());
   }
 
-  #[@test, @expect('lang.IllegalStateException')]
+  #[@test, @expect(IllegalStateException::class)]
   public function no_auth_when_not_indicated() {
     Authorizations::fromResponse(new HttpResponse(new MemoryInputStream("HTTP/1.0 200 OK")), 'user', new SecureString('pass'));
   }
@@ -63,7 +64,7 @@ class DigestAuthTest extends \unittest\TestCase {
     );
   }
 
-  #[@test, @expect('lang.MethodNotImplementedException')]
+  #[@test, @expect(MethodNotImplementedException::class)]
   public function only_md5_algorithm_supported() {
     $this->http->setResponse(new HttpResponse(new MemoryInputStream(
       "HTTP/1.0 401 Unauthorized\r\n".
@@ -170,7 +171,7 @@ class DigestAuthTest extends \unittest\TestCase {
   }
 
 
-  #[@test, @expect('lang.MethodNotImplementedException')]
+  #[@test, @expect(MethodNotImplementedException::class)]
   public function only_md5_is_supported_algorithm() {
     $digest= DigestAuthorization::fromChallenge(
       'WWW-Authenticate: Digest realm="testrealm@host.com", '.

--- a/src/test/php/peer/http/unittest/HttpInputStreamTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpInputStreamTest.class.php
@@ -51,7 +51,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertRead($data) {
-    with ($length= strlen($data), $r= $this->httpResponse(HttpConstants::STATUS_OK, array('Content-Length' => $length), $data)); {
+    with ($length= strlen($data), $r= $this->httpResponse(HttpConstants::STATUS_OK, ['Content-Length' => $length], $data)); {
     
       // Self-testing
       $this->assertEquals(HttpConstants::STATUS_OK, $r->statusCode());
@@ -85,7 +85,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
   public function available() {
     with ($s= new HttpInputStream($this->httpResponse(
       HttpConstants::STATUS_OK, 
-      array('Content-Length' => 10), 
+      ['Content-Length' => 10], 
       'HelloWorld'
     ))); {
 
@@ -103,7 +103,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
   public function availableWithChunks() {
     with ($s= new HttpInputStream($this->httpResponse(
       HttpConstants::STATUS_OK, 
-      array('Transfer-Encoding' => 'chunked'), 
+      ['Transfer-Encoding' => 'chunked'], 
       "5\r\nHello\r\n".
       "5\r\nWorld\r\n".
       "0\r\n"
@@ -123,7 +123,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
   public function availableAfterReadingAll() {
     with ($s= new HttpInputStream($this->httpResponse(
       HttpConstants::STATUS_OK, 
-      array('Content-Length' => 10), 
+      ['Content-Length' => 10], 
       'HelloWorld'
     ))); {
       $this->readAll($s);
@@ -135,7 +135,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
   public function readAfterReadingAll() {
     with ($s= new HttpInputStream($this->httpResponse(
       HttpConstants::STATUS_OK, 
-      array('Content-Length' => 10), 
+      ['Content-Length' => 10], 
       'HelloWorld'
     ))); {
       $this->readAll($s);
@@ -147,7 +147,7 @@ class HttpInputStreamTest extends \unittest\TestCase {
   public function availableWhenBuffered() {
     with ($s= new HttpInputStream($this->httpResponse(
       HttpConstants::STATUS_OK, 
-      array('Content-Length' => 10), 
+      ['Content-Length' => 10], 
       'HelloWorld'
     ))); {
       $s->read(5);

--- a/src/test/php/peer/http/unittest/HttpProxyTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpProxyTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http\unittest;
 
+use lang\IllegalArgumentException;
 use peer\URL;
 use peer\http\HttpProxy;
 
@@ -57,7 +58,7 @@ class HttpProxyTest extends \unittest\TestCase {
     $this->assertEquals(['proxy.example.com', 3128], [$proxy->host(), $proxy->port()]);
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_create_with_host_only_authority() {
     new HttpProxy('proxy.example.com', null);
   }

--- a/src/test/php/peer/http/unittest/HttpResponseTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpResponseTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http\unittest;
 
+use lang\FormatException;
 use peer\http\HttpResponse;
 use io\streams\MemoryInputStream;
 
@@ -24,36 +25,36 @@ class HttpResponseTest extends \unittest\TestCase {
   #[@test]
   public function errorDocument() {
     $body= '<h1>File not found</h1>';
-    $response= $this->newResponse(array('HTTP/1.0 404 OK', 'Content-Length: 23', 'Content-Type: text/html'), $body);
+    $response= $this->newResponse(['HTTP/1.0 404 OK', 'Content-Length: 23', 'Content-Type: text/html'], $body);
     $this->assertEquals(404, $response->statusCode());
-    $this->assertEquals(array('23'), $response->header('Content-Length'));
-    $this->assertEquals(array('text/html'), $response->header('Content-Type'));
+    $this->assertEquals(['23'], $response->header('Content-Length'));
+    $this->assertEquals(['text/html'], $response->header('Content-Type'));
     $this->assertEquals($body, $response->readData());
   }
 
   #[@test]
   public function emptyDocument() {
-    $response= $this->newResponse(array('HTTP/1.0 204 No content'));
+    $response= $this->newResponse(['HTTP/1.0 204 No content']);
     $this->assertEquals(204, $response->statusCode());
   }
 
   #[@test]
   public function chunkedDocument() {
     $body= '<h1>File not found</h1>';
-    $response= $this->newResponse(array('HTTP/1.0 404 OK', 'Transfer-Encoding: chunked'), "17\r\n".$body."\r\n0\r\n");
+    $response= $this->newResponse(['HTTP/1.0 404 OK', 'Transfer-Encoding: chunked'], "17\r\n".$body."\r\n0\r\n");
     $this->assertEquals(404, $response->statusCode());
-    $this->assertEquals(array('chunked'), $response->header('Transfer-Encoding'));
+    $this->assertEquals(['chunked'], $response->header('Transfer-Encoding'));
     $this->assertEquals($body, $response->readData());
   }
 
   #[@test]
   public function multipleChunkedDocument() {
     $response= $this->newResponse(
-      array('HTTP/1.0 404 OK', 'Transfer-Encoding: chunked'),
+      ['HTTP/1.0 404 OK', 'Transfer-Encoding: chunked'],
       "17\r\n<h1>File not found</h1>\r\n13\r\nDid my best, sorry.\r\n0\r\n"
     );
     $this->assertEquals(404, $response->statusCode());
-    $this->assertEquals(array('chunked'), $response->header('Transfer-Encoding'));
+    $this->assertEquals(['chunked'], $response->header('Transfer-Encoding'));
     
     // Read data & test body contents
     $buffer= ''; while ($l= $response->readData()) { $buffer.= $l; }
@@ -62,15 +63,15 @@ class HttpResponseTest extends \unittest\TestCase {
 
   #[@test]
   public function httpContinue() {
-    $response= $this->newResponse(array('HTTP/1.0 100 Continue', '', 'HTTP/1.0 200 OK', 'Content-Length: 4'), 'Test');
+    $response= $this->newResponse(['HTTP/1.0 100 Continue', '', 'HTTP/1.0 200 OK', 'Content-Length: 4'], 'Test');
     $this->assertEquals(200, $response->statusCode());
-    $this->assertEquals(array('4'), $response->header('Content-Length'));
+    $this->assertEquals(['4'], $response->header('Content-Length'));
     $this->assertEquals('Test', $response->readData());
   }
   
   #[@test]
   public function statusCodeWithMessage() {
-    $response= $this->newResponse(array('HTTP/1.1 404 Not Found'), 'File Not Found');
+    $response= $this->newResponse(['HTTP/1.1 404 Not Found'], 'File Not Found');
     $this->assertEquals(404, $response->statusCode());
     $this->assertEquals('Not Found', $response->message());
     $this->assertEquals('File Not Found', $response->readData());
@@ -78,40 +79,40 @@ class HttpResponseTest extends \unittest\TestCase {
   
   #[@test]
   public function statusCodeWithoutMessage() {
-    $response= $this->newResponse(array('HTTP/1.1 404'), 'File Not Found');
+    $response= $this->newResponse(['HTTP/1.1 404'], 'File Not Found');
     $this->assertEquals(404, $response->statusCode());
     $this->assertEquals('', $response->message());
     $this->assertEquals('File Not Found', $response->readData());
   }
 
-  #[@test, @expect('lang.FormatException')]
+  #[@test, @expect(FormatException::class)]
   public function incorrectProtocol() {
-    $this->newResponse(array('* OK IMAP server ready H mimap20 68140'));
+    $this->newResponse(['* OK IMAP server ready H mimap20 68140']);
   }
 
   #[@test]
   public function getHeader() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
     $this->assertEquals('6100', $response->getHeader('X-Binford'));
     $this->assertEquals('text/html', $response->getHeader('Content-Type'));
   }
 
   #[@test]
   public function getHeaderIsCaseInsensitive() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
     $this->assertEquals('6100', $response->getHeader('x-binford'), 'all-lowercase');
     $this->assertEquals('text/html', $response->getHeader('CONTENT-TYPE'), 'all-uppercase');
   }
 
   #[@test]
   public function nonExistantGetHeader() {
-    $response= $this->newResponse(array('HTTP/1.0 204 No Content'));
+    $response= $this->newResponse(['HTTP/1.0 204 No Content']);
     $this->assertNull($response->getHeader('Via'));
   }
 
   #[@test]
   public function multipleCookiesInGetHeader() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/']);
     $this->assertEquals(
       'make=example; path=/',
       $response->getHeader('Set-Cookie')
@@ -120,108 +121,108 @@ class HttpResponseTest extends \unittest\TestCase {
 
   #[@test]
   public function getHeaders() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
     $this->assertEquals(
-      array('X-Binford' => '6100', 'Content-Type' => 'text/html'),
+      ['X-Binford' => '6100', 'Content-Type' => 'text/html'],
       $response->getHeaders()
     );
   }
 
   #[@test]
   public function emptyGetHeaders() {
-    $response= $this->newResponse(array('HTTP/1.0 204 No Content'));
+    $response= $this->newResponse(['HTTP/1.0 204 No Content']);
     $this->assertEquals(
-      array(),
+      [],
       $response->getHeaders()
     );
   }
 
   #[@test]
   public function multipleCookiesInGetHeaders() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/']);
     $this->assertEquals(
-      array('Set-Cookie' => 'make=example; path=/'),
+      ['Set-Cookie' => 'make=example; path=/'],
       $response->getHeaders('Set-Cookie')
     );
   }
 
   #[@test]
   public function header() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
-    $this->assertEquals(array('6100'), $response->header('X-Binford'));
-    $this->assertEquals(array('text/html'), $response->header('Content-Type'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
+    $this->assertEquals(['6100'], $response->header('X-Binford'));
+    $this->assertEquals(['text/html'], $response->header('Content-Type'));
   }
 
   #[@test]
   public function headerIsCaseInsensitive() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
-    $this->assertEquals(array('6100'), $response->header('x-binford'), 'all-lowercase');
-    $this->assertEquals(array('text/html'), $response->header('CONTENT-TYPE'), 'all-uppercase');
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
+    $this->assertEquals(['6100'], $response->header('x-binford'), 'all-lowercase');
+    $this->assertEquals(['text/html'], $response->header('CONTENT-TYPE'), 'all-uppercase');
   }
 
   #[@test]
   public function nonExistantHeader() {
-    $response= $this->newResponse(array('HTTP/1.0 204 No Content'));
+    $response= $this->newResponse(['HTTP/1.0 204 No Content']);
     $this->assertNull($response->header('Via'));
   }
 
   #[@test]
   public function multipleCookiesInHeader() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/']);
     $this->assertEquals(
-      array('color=green; path=/', 'make=example; path=/'),
+      ['color=green; path=/', 'make=example; path=/'],
       $response->header('Set-Cookie')
     );
   }
 
   #[@test]
   public function multipleCookiesInHeaders() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'Set-Cookie: color=green; path=/', 'Set-Cookie: make=example; path=/']);
     $this->assertEquals(
-      array('Set-Cookie' => array('color=green; path=/', 'make=example; path=/')),
+      ['Set-Cookie' => ['color=green; path=/', 'make=example; path=/']],
       $response->headers()
     );
   }
 
   #[@test]
   public function headers() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Binford: 6100', 'Content-Type: text/html']);
     $this->assertEquals(
-      array('X-Binford' => array('6100'), 'Content-Type' => array('text/html')),
+      ['X-Binford' => ['6100'], 'Content-Type' => ['text/html']],
       $response->headers()
     );
   }
 
   #[@test]
   public function emptyHeaders() {
-    $response= $this->newResponse(array('HTTP/1.0 204 No Content'));
+    $response= $this->newResponse(['HTTP/1.0 204 No Content']);
     $this->assertEquals(
-      array(),
+      [],
       $response->headers()
     );
   }
 
   #[@test]
   public function multipleHeadersWithDifferentCasing() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Example: K', 'x-example: V'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Example: K', 'x-example: V']);
     $this->assertEquals(
-      array('X-Example' => array('K', 'V')),
+      ['X-Example' => ['K', 'V']],
       $response->headers()
     );
   }
 
   #[@test]
   public function multipleHeaderWithDifferentCasing() {
-    $response= $this->newResponse(array('HTTP/1.0 200 OK', 'X-Example: K', 'x-example: V'));
+    $response= $this->newResponse(['HTTP/1.0 200 OK', 'X-Example: K', 'x-example: V']);
     $this->assertEquals(
-      array('K', 'V'),
+      ['K', 'V'],
       $response->header('X-Example')
     );
   }
 
   #[@test]
   public function headerString() {
-    $response= $this->newResponse(array('HTTP/1.1 200 OK', 'Content-Type: application/json', 'Content-Length: 0'));
+    $response= $this->newResponse(['HTTP/1.1 200 OK', 'Content-Type: application/json', 'Content-Length: 0']);
     $this->assertEquals(
       "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 0\r\n\r\n",
       $response->getHeaderString()
@@ -230,7 +231,7 @@ class HttpResponseTest extends \unittest\TestCase {
 
   #[@test]
   public function headerStringDoesNotIncludeContent() {
-    $response= $this->newResponse(array('HTTP/1.1 200 OK', 'Content-Type: application/json', 'Content-Length: 21'), '{ "hello" : "world" }');
+    $response= $this->newResponse(['HTTP/1.1 200 OK', 'Content-Type: application/json', 'Content-Length: 21'], '{ "hello" : "world" }');
     $this->assertEquals(
       "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 21\r\n\r\n",
       $response->getHeaderString()
@@ -240,9 +241,9 @@ class HttpResponseTest extends \unittest\TestCase {
   #[@test]
   public function headerWithoutValue() {
     $body= '.';
-    $response= $this->newResponse(array('HTTP/1.1 401 Unauthorized', 'Cache-Control: '), $body);
+    $response= $this->newResponse(['HTTP/1.1 401 Unauthorized', 'Cache-Control: '], $body);
     $this->assertEquals(401, $response->statusCode());
-    $this->assertEquals(array(null), $response->header('Cache-Control'));
+    $this->assertEquals([null], $response->header('Cache-Control'));
     $this->assertEquals($body, $response->readData());
   }
 }

--- a/src/test/php/peer/http/unittest/HttpTransportTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpTransportTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http\unittest;
 
+use lang\IllegalArgumentException;
 use peer\URL;
 use peer\http\HttpTransport;
 use peer\http\HttpProxy;
@@ -16,7 +17,7 @@ class HttpTransportTest extends \unittest\TestCase {
    */
   #[@beforeClass]
   public static function registerTransport() {
-    HttpTransport::register('test', \lang\ClassLoader::defineClass('TestHttpTransport', 'peer.http.HttpTransport', array(), '{
+    HttpTransport::register('test', \lang\ClassLoader::defineClass('TestHttpTransport', 'peer.http.HttpTransport', [], '{
       public $host, $port, $arg, $proxy;
 
       public function __construct(\peer\URL $url, $arg) {
@@ -35,7 +36,7 @@ class HttpTransportTest extends \unittest\TestCase {
     }'));
   }
 
-  #[@test, @expect('lang.IllegalArgumentException')]
+  #[@test, @expect(IllegalArgumentException::class)]
   public function registerIncorrectClass() {
     HttpTransport::register('irrelevant', $this->getClass());
   }


### PR DESCRIPTION
Converted using [this unperfect script](https://gist.github.com/thekid/d87c0db1f5902af26c4f) using PHP 5.4 mode