### PR TITLE
Allow supplying path along with parameters

### DIFF
--- a/src/main/php/peer/http/HttpConnection.class.php
+++ b/src/main/php/peer/http/HttpConnection.class.php
@@ -167,7 +167,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a GET request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -178,7 +178,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a HEAD request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -189,7 +189,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a POST request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -200,7 +200,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a PUT request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -211,7 +211,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a PATCH request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -222,7 +222,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a DELETE request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -233,7 +233,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform an OPTIONS request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */
@@ -244,7 +244,7 @@ class HttpConnection extends \lang\Object implements Traceable {
   /**
    * Perform a TRACE request
    *
-   * @param   string $arg default NULL
+   * @param   [:string]|string $parameters Request parameters
    * @param   [:var] $headers default array()
    * @return  peer.http.HttpResponse response object
    */

--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -75,17 +75,24 @@ class HttpRequest extends \lang\Object {
   /**
    * Set request parameters
    *
-   * @param   var p either a string, a RequestData object or an associative array
+   * @param  var $arg either a string, a RequestData object or an associative array
    */
-  public function setParameters($p) {
-    if ($p instanceof RequestData) {
-      $this->parameters= $p;
+  public function setParameters($arg) {
+    if ($arg instanceof RequestData) {
+      $this->parameters= $arg;
       return;
-    } else if (is_string($p)) {
-      parse_str($p, $out); 
-      $params= $out;
-    } else if (is_array($p)) {
-      $params= $p;
+    } else if (is_string($arg)) {
+      if ('' === $arg) {
+        $params= [];
+      } else if ('/' === $arg{0}) {
+        sscanf($arg, "%[^?]?%[^\r]", $path, $query);
+        $this->setTarget($path);
+        parse_str($query, $params);
+      } else {
+        parse_str($arg, $params);
+      }
+    } else if (is_array($arg)) {
+      $params= $arg;
     } else {
       $params= [];
     }

--- a/src/test/php/peer/http/unittest/HttpConnectionTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpConnectionTest.class.php
@@ -35,6 +35,24 @@ class HttpConnectionTest extends TestCase {
       $this->fixture->lastRequest()
     );
   }
+
+  #[@test]
+  public function get_with_path() {
+    $this->fixture->get('/test');
+    $this->assertEquals(
+      "GET /test HTTP/1.1\r\nConnection: close\r\nHost: example.com:80\r\n\r\n",
+      $this->fixture->lastRequest()
+    );
+  }
+
+  #[@test]
+  public function get_with_path_and_parameters() {
+    $this->fixture->get('/test?a=b&c=d');
+    $this->assertEquals(
+      "GET /test?a=b&c=d HTTP/1.1\r\nConnection: close\r\nHost: example.com:80\r\n\r\n",
+      $this->fixture->lastRequest()
+    );
+  }
   
   #[@test]
   public function head() {
@@ -172,5 +190,4 @@ class HttpConnectionTest extends TestCase {
       $conn->lastRequest()
     );
   }
-
 }


### PR DESCRIPTION
Example:

```php
$conn= new HttpConnection('http://example.com');
$conn->get('/index.html');
$conn->get('/index.php?name=Test');
```