### PR TITLE
Streaming requests

### DIFF
--- a/src/main/php/peer/http/ChunkedHttpOutputStream.class.php
+++ b/src/main/php/peer/http/ChunkedHttpOutputStream.class.php
@@ -1,0 +1,40 @@
+<?php namespace peer\http;
+
+class ChunkedHttpOutputStream extends HttpOutputStream {
+  const BUFFER_SIZE = 4096;
+
+  public $socket;
+  private $buffer= '', $closed= false;
+
+  /** @param peer.Socket $socket */
+  public function __construct($socket) {
+    $this->socket= $socket;
+  }
+
+  /**
+   * Write given bytes
+   *
+   * @param  string $bytes
+   * @return void
+   */
+  public function write($bytes) {
+    $this->buffer.= $bytes;
+    if (strlen($this->buffer) > self::BUFFER_SIZE) {
+      $this->socket->write(dechex(strlen($this->buffer))."\r\n".$this->buffer."\r\n");
+      $this->buffer= '';
+    }
+  }
+
+  /** @return void */
+  public function close() {
+    if ($this->closed) return;
+
+    if ('' === $this->buffer) {
+      $this->socket->write("0\r\n\r\n");
+      $this->closed= true;
+    } else {
+      $this->socket->write(dechex(strlen($this->buffer))."\r\n".$this->buffer."\r\n0\r\n\r\n");
+      $this->closed= true;
+    }
+  }
+}

--- a/src/main/php/peer/http/CurlHttpOutputStream.class.php
+++ b/src/main/php/peer/http/CurlHttpOutputStream.class.php
@@ -1,0 +1,21 @@
+<?php namespace peer\http;
+
+class CurlHttpOutputStream extends HttpOutputStream {
+  public $bytes= '';
+  public $handle, $proxied;
+
+  public function __construct($handle, $proxied) {
+    $this->handle= $handle;
+    $this->proxied= $proxied;
+  }
+
+  /**
+   * Write given bytes
+   *
+   * @param  string $bytes
+   * @return void
+   */
+  public function write($bytes) {
+    $this->bytes.= $bytes;
+  }
+}

--- a/src/main/php/peer/http/CurlHttpTransport.class.php
+++ b/src/main/php/peer/http/CurlHttpTransport.class.php
@@ -85,6 +85,7 @@ class CurlHttpTransport extends HttpTransport {
    * @return peer.http.HttpResponse
    */
   public function finish($stream) {
+    $stream->close();
     if ('' !== $stream->bytes) {
       curl_setopt($stream->handle, CURLOPT_POSTFIELDS, $stream->bytes);
     }

--- a/src/main/php/peer/http/CurlHttpTransport.class.php
+++ b/src/main/php/peer/http/CurlHttpTransport.class.php
@@ -1,5 +1,6 @@
 <?php namespace peer\http;
 
+use io\IOException;
 use io\streams\MemoryInputStream;
 use peer\URL;
 
@@ -10,7 +11,7 @@ use peer\URL;
  * @see   xp://peer.http.HttpConnection
  */
 class CurlHttpTransport extends HttpTransport {
-  protected $handle = null;
+  private $ssl= null;
 
   static function __static() { }
 
@@ -21,14 +22,82 @@ class CurlHttpTransport extends HttpTransport {
    * @param   string $arg
    */
   public function __construct(URL $url, $arg) {
-    $this->handle= curl_init();
-    curl_setopt($this->handle, CURLOPT_HEADER, 1);
-    curl_setopt($this->handle, CURLOPT_RETURNTRANSFER, 1); 
-    curl_setopt($this->handle, CURLOPT_SSL_VERIFYHOST, 0);
-    curl_setopt($this->handle, CURLOPT_SSL_VERIFYPEER, 0);
-    if (1 === sscanf($arg, 'v%d', $version)) {
-      curl_setopt($this->handle, CURLOPT_SSLVERSION, $version);
+    sscanf($arg, 'v%d', $this->ssl);
+  }
+
+  /**
+   * Opens a request
+   *
+   * @param   peer.http.HttpRequest $request
+   * @param   float $connectTimeout default 2.0
+   * @param   float $readTimeout default 60.0
+   * @return  peer.http.HttpOutputStream
+   */
+  public function open(HttpRequest $request, $connectTimeout= 2.0, $readTimeout= 60.0) {
+    static $versions= [
+      HttpConstants::VERSION_1_0 => CURL_HTTP_VERSION_1_0,
+      HttpConstants::VERSION_1_1 => CURL_HTTP_VERSION_1_1,
+    ];
+
+    $header= $request->getHeaderString();
+    $handle= curl_init();
+    curl_setopt_array($handle, [
+      CURLOPT_HEADER         => true,
+      CURLOPT_RETURNTRANSFER => true,
+      CURLOPT_SSL_VERIFYHOST => 2,
+      CURLOPT_SSL_VERIFYPEER => 0,
+      CURLOPT_URL            => $request->url->getCanonicalURL(),
+      CURLOPT_CUSTOMREQUEST  => $request->method,
+      CURLOPT_CONNECTTIMEOUT => $connectTimeout,
+      CURLOPT_TIMEOUT        => $readTimeout,
+      CURLOPT_HTTPHEADER     => explode("\r\n", $header),
+      CURLOPT_HTTP_VERSION   => isset($versions[$request->version]) ? $versions[$request->version] : CURL_HTTP_VERSION_NONE,
+      CURLOPT_SSLVERSION     => $this->ssl,
+    ]);
+
+    if ($this->proxy && !$this->proxy->excludes()->contains($request->getUrl())) {
+      curl_setopt_array($handle, [
+        CURLOPT_PROXY     => $this->proxy->host(),
+        CURLOPT_PROXYPORT => $this->proxy->port(),
+      ]);
+      $proxied= true;
+    } else {
+      $proxied= false;
     }
+
+    $this->cat && $this->cat->info('>>>', $header);
+    return new CurlHttpOutputStream($handle, $proxied);
+  }
+
+  /**
+   * Finishes a transfer and returns the response
+   *
+   * @param  peer.http.HttpOutputStream $stream
+   * @return peer.http.HttpResponse
+   */
+  public function finish($stream) {
+    if ('' !== $stream->bytes) {
+      curl_setopt($stream->handle, CURLOPT_POSTFIELDS, $stream->bytes);
+    }
+
+    $transfer= curl_exec($stream->handle);
+    if (false === $transfer) {
+      $error= curl_errno($stream->handle);
+      $message= curl_error($stream->handle);
+      curl_close($stream->handle);
+      throw new IOException($error.' '.$message);
+    }
+
+    // Strip "HTTP/x.x 200 Connection established" which is followed by
+    // the real HTTP message: headers and body
+    if ($stream->proxied) {
+      $transfer= preg_replace('#^HTTP/[0-9]\.[0-9] [0-9]{3} .+\r\n\r\n#', '', $transfer);
+    }
+
+    curl_close($stream->handle);
+    $response= new HttpResponse(new MemoryInputStream($transfer), false);
+    $this->cat && $this->cat->info('<<<', $response->getHeaderString());
+    return $response;
   }
 
   /**

--- a/src/main/php/peer/http/HttpConnection.class.php
+++ b/src/main/php/peer/http/HttpConnection.class.php
@@ -124,20 +124,45 @@ class HttpConnection implements Traceable {
   }
 
   /**
+   * Opens a HTTP transfer
+   *
+   * ```php
+   * $transfer= $this->conn->open($request);
+   * $transfer->write(...);
+   *
+   * $response= $this->conn->finish($transfer);
+   * ```
+   *
+   * @param   peer.http.HttpRequest $request
+   * @return  peer.http.HttpOutputStream
+   */
+  public function open(HttpRequest $request) {
+    return $this->transport->open($request, $this->_ctimeout, $this->_timeout);
+  }
+
+  /**
+   * Finishes a transfer and returns the response
+   *
+   * @param  peer.http.HttpOutputStream $stream
+   * @return peer.http.HttpResponse
+   */
+  public function finish(HttpOutputStream $stream) {
+    return $this->transport->finish($stream);
+  }
+
+  /**
    * Creates a new HTTP request. For use in conjunction with send(), e.g.:
    *
-   * <code>
-   *   $conn= new HttpConnection('http://example.com/');
+   * ```php
+   * $conn= new HttpConnection('http://example.com/');
    *   
-   *   with ($request= $conn->create(new HttpRequest())); {
-   *     $request->setMethod(HttpConstants::GET);
-   *     $request->setParameters(array('a' => 'b'));
-   *     $request->setHeader('X-Binford', '6100 (more power)');
+   * $request= $conn->create(new HttpRequest());
+   * $request->setMethod(HttpConstants::GET);
+   * $request->setParameters(array('a' => 'b'));
+   * $request->setHeader('X-Binford', '6100 (more power)');
    *
-   *     $response= $conn->send($request);
-   *     // ...
-   *   }
-   * </code>
+   * $response= $conn->send($request);
+   * ```
    *
    * @param   peer.http.HttpRequest $r
    * @return  peer.http.HttpRequest request object

--- a/src/main/php/peer/http/HttpOutputStream.class.php
+++ b/src/main/php/peer/http/HttpOutputStream.class.php
@@ -1,0 +1,21 @@
+<?php namespace peer\http;
+
+use io\streams\OutputStream;
+
+/**
+ * HTTP transfer (client -> server)
+ *
+ * @see   xp://peer.http.HttpConnection::open
+ */
+abstract class HttpOutputStream implements OutputStream {
+
+  /** @return void */
+  public function flush() {
+    // NOOP, overwrite in subclasses if necessary
+  }
+  
+  /** @return void */
+  public function close() {
+    // NOOP, overwrite in subclasses if necessary
+  }
+}

--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -175,8 +175,10 @@ class HttpRequest {
     } else {
       if ($withBody) $body= substr($query, 1);
       if (null !== $this->url->getQuery()) $target.= '?'.$this->url->getQuery();
-      $this->headers['Content-Length']= [max(0, strlen($query)- 1)];
-      if (empty($this->headers['Content-Type'])) {
+      if (!isset($this->headers['Content-Length'])) {
+        $this->headers['Content-Length']= [max(0, strlen($query)- 1)];
+      }
+      if (!isset($this->headers['Content-Type'])) {
         $this->headers['Content-Type']= ['application/x-www-form-urlencoded'];
       }
     }

--- a/src/main/php/peer/http/HttpRequest.class.php
+++ b/src/main/php/peer/http/HttpRequest.class.php
@@ -133,6 +133,28 @@ class HttpRequest {
     }
   }
 
+  /** @return string */
+  public function target() {
+    $params= '';
+    foreach ($this->parameters as $name => $value) {
+      if (is_array($value)) {
+        foreach ($value as $k => $v) {
+          $params.= '&'.urlencode($name).'['.urlencode($k).']='.urlencode($v);
+        }
+      } else {
+        $params.= '&'.urlencode($name).'='.urlencode($value);
+      }
+    }
+
+    if (null !== ($query= $this->url->getQuery())) {
+      return $this->target.'?'.$query.$params;
+    } else if ($params) {
+      return $this->target.'?'.substr($params, 1);
+    } else {
+      return $this->target;
+    }
+  }
+
   /**
    * Returns payload
    *

--- a/src/main/php/peer/http/HttpResponse.class.php
+++ b/src/main/php/peer/http/HttpResponse.class.php
@@ -155,8 +155,11 @@ class HttpResponse implements Value {
     }
 
     // A chunk of size 0 means we're at the end of the document. We 
-    // ignore any trailers.
-    if (0 == $chunksize) return $this->closeStream();
+    // read the next line but ignore any trailers.
+    if (0 === $chunksize) {
+      $this->readChunk(2);
+      return $this->closeStream();
+    }
 
     // A chunk is terminated by \r\n, so scan over two more characters
     $chunk= $this->readChunk($chunksize);

--- a/src/main/php/peer/http/HttpTransport.class.php
+++ b/src/main/php/peer/http/HttpTransport.class.php
@@ -1,7 +1,7 @@
 <?php namespace peer\http;
 
-use peer\URL;
 use lang\XPClass;
+use peer\URL;
 use peer\http\proxy\EnvironmentSettings;
 use peer\http\proxy\RegistrySettings;
 

--- a/src/main/php/peer/http/SocketHttpOutputStream.class.php
+++ b/src/main/php/peer/http/SocketHttpOutputStream.class.php
@@ -1,0 +1,20 @@
+<?php namespace peer\http;
+
+class SocketHttpOutputStream extends HttpOutputStream {
+  public $socket;
+
+  /** @param peer.Socket $socket */
+  public function __construct($socket) {
+    $this->socket= $socket;
+  }
+
+  /**
+   * Write given bytes
+   *
+   * @param  string $bytes
+   * @return void
+   */
+  public function write($bytes) {
+    $this->socket->write($bytes);
+  }
+}

--- a/src/main/php/peer/http/SocketHttpTransport.class.php
+++ b/src/main/php/peer/http/SocketHttpTransport.class.php
@@ -108,9 +108,11 @@ class SocketHttpTransport extends HttpTransport {
       }
     }
 
+    // Check for chunked transfer encoding
     $this->cat && $this->cat->info('>>>', $header);
     $s->write($header."\r\n");
-    return new SocketHttpOutputStream($s);
+    $chunked= stristr($header, 'Transfer-Encoding: chunked');
+    return $chunked ? new ChunkedHttpOutputStream($s) : new SocketHttpOutputStream($s);
   }
 
   /**
@@ -120,6 +122,8 @@ class SocketHttpTransport extends HttpTransport {
    * @return peer.http.HttpResponse
    */
   public function finish($stream) {
+    $stream->close();
+
     $response= new HttpResponse(new SocketInputStream($stream->socket));
     $this->cat && $this->cat->info('<<<', $response->getHeaderString());
     return $response;

--- a/src/main/php/peer/http/SocketHttpTransport.class.php
+++ b/src/main/php/peer/http/SocketHttpTransport.class.php
@@ -101,9 +101,15 @@ class SocketHttpTransport extends HttpTransport {
     }
 
     // Send headers, then return control to caller
-    $header= $request->getHeaderString();
+    $header= $request->method.' '.$request->target().' HTTP/'.$request->version."\r\n";
+    foreach ($request->headers as $name => $values) {
+      foreach ($values as $value) {
+        $header.= $name.': '.$value."\r\n";
+      }
+    }
+
     $this->cat && $this->cat->info('>>>', $header);
-    $s->write($header);
+    $s->write($header."\r\n");
     return new SocketHttpOutputStream($s);
   }
 

--- a/src/test/php/peer/http/unittest/HttpConnectionTest.class.php
+++ b/src/test/php/peer/http/unittest/HttpConnectionTest.class.php
@@ -1,15 +1,15 @@
 <?php namespace peer\http\unittest;
 
-use util\log\Traceable;
-use unittest\TestCase;
 use peer\URL;
+use peer\http\BasicAuthorization;
+use peer\http\HttpConstants;
 use peer\http\HttpProxy;
 use peer\http\HttpRequest;
-use peer\http\HttpConstants;
 use peer\http\RequestData;
-use peer\http\BasicAuthorization;
-use util\log\LogCategory;
+use unittest\TestCase;
 use util\log\BufferedAppender;
+use util\log\LogCategory;
+use util\log\Traceable;
 use util\log\layout\PatternLayout;
 
 /**
@@ -173,4 +173,27 @@ class HttpConnectionTest extends TestCase {
     );
   }
 
+  #[@test]
+  public function open_transfer() {
+    $request= $this->fixture->create(new HttpRequest());
+    $request->setMethod('POST');
+    $request->setTarget('/');
+    $request->setHeader('Content-Length', 13);
+    $request->setHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+    $transfer= $this->fixture->open($request);
+    $transfer->write('var1=1&var2=2');
+    $this->fixture->finish($transfer);
+
+    $this->assertEquals(
+      "POST / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: example.com:80\r\n".
+      "Content-Length: 13\r\n".
+      "Content-Type: application/x-www-form-urlencoded\r\n".
+      "\r\n".
+      "var1=1&var2=2",
+      $this->fixture->lastRequest()
+    );
+  }
 }

--- a/src/test/php/peer/http/unittest/MockHttpOutputStream.class.php
+++ b/src/test/php/peer/http/unittest/MockHttpOutputStream.class.php
@@ -1,0 +1,17 @@
+<?php namespace peer\http\unittest;
+
+use peer\http\HttpOutputStream;
+
+class MockHttpOutputStream extends HttpOutputStream {
+  public $bytes= '';
+
+  /**
+   * Write given bytes
+   *
+   * @param  string $bytes
+   * @return void
+   */
+  public function write($bytes) {
+    $this->bytes.= $bytes;
+  }
+}


### PR DESCRIPTION
This adds a new API to stream requests:

```php
use peer\http\HttpConnection;
use peer\http\HttpRequest;
use util\cmd\Console;

$data= 'var1=1&var2=2';

$conn= new HttpConnection('http://localhost:8080/target');

$req= $conn->create(new HttpRequest());
$req->setMethod('POST');
$req->setHeader('Content-Type', 'application/x-www-form-urlencoded');
$req->setHeader('Content-Length', strlen($data));
$req->setHeader('X-User-Id', 6100);

$transfer= $conn->open($req);
$transfer->write($data);
$res= $conn->finish($transfer);

Console::writeLine($res);
```