### PR TITLE
Fix for proxy handling in SSLSocketHttpTransport and CurlHttpTransport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+composer.lock
+vendor/
+

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,9 @@
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]
+  },
+  "suggest": {
+    "ext-openssl": "Allows to use SSL/TLS, e.g. for https-connections",
+    "ext-curl": "Alternative to ext-openssl for SSL-/TLS connections"
   }
 }

--- a/src/main/php/peer/http/SocketHttpTransport.class.php
+++ b/src/main/php/peer/http/SocketHttpTransport.class.php
@@ -70,6 +70,7 @@ class SocketHttpTransport extends HttpTransport {
    * @param  peer.Socket $s Connection to proxy
    * @param  peer.http.HttpRequest $request
    * @param  peer.URL $url
+   * @return peer.Socket
    */
   protected function proxy($s, $request, $url) {
     $request->setTarget(sprintf(
@@ -79,6 +80,7 @@ class SocketHttpTransport extends HttpTransport {
       $url->getPort() ? ':'.$url->getPort() : '',
       $url->getPath('/')
     ));
+    return $s;
   }
 
   /**
@@ -95,7 +97,7 @@ class SocketHttpTransport extends HttpTransport {
     // a proxy wants "GET http://example.com/ HTTP/X.X" for (and "CONNECT" for HTTPs).
     if ($this->proxy && !$this->proxy->excludes()->contains($url= $request->getUrl())) {
       $s= $this->connect($this->proxySocket, $readTimeout, $connectTimeout);
-      $this->proxy($s, $request, $url);
+      $s= $this->proxy($s, $request, $url);
     } else {
       $s= $this->connect($this->socket, $readTimeout, $connectTimeout);
     }
@@ -143,7 +145,7 @@ class SocketHttpTransport extends HttpTransport {
     // a proxy wants "GET http://example.com/ HTTP/X.X" for (and "CONNECT" for HTTPs).
     if ($this->proxy && !$this->proxy->excludes()->contains($url= $request->getUrl())) {
       $s= $this->connect($this->proxySocket, $timeout, $connecttimeout);
-      $this->proxy($s, $request, $url);
+      $s= $this->proxy($s, $request, $url);
     } else {
       $s= $this->connect($this->socket, $timeout, $connecttimeout);
     }


### PR DESCRIPTION
Hi,
we needed the proxy functionality and realized there were some bugs:
* CurlHttpTransport
  * curl-handle management was broken
* SSLSocketHttpTransport
  * encryption algorithm check needed a new connection for each try (foreach in "enable" didn't work)
  * that's why SSLSocketHttpTransport::proxy may return a new peer.Socket

Other things i missed:
* gitignore file missing
  * exclude vendor-folder
  * excluded the IDEs folders
  * excluded composer.lock as it is dependent on the developing system
* composer.json: added "suggest" section as the note in the README.md seems like too little if there is tool support for that

hth